### PR TITLE
instagram 'seen' request url changed

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@ chrome.webRequest.onBeforeRequest.addListener(
 	() => ({
 		cancel: isActive
 	}),
-	{ urls: [ '*://*.instagram.com/stories/reel/seen*' ] },
+	{ urls: [ '*://*.instagram.com/api/v1/stories/reel/seen*' ] },
 	[ 'blocking' ]
 );
 


### PR DESCRIPTION
Instagram recently changed the api url, here's the new one to block the 'seen' request.