### PR TITLE
Block only GraphQL requests that contain a reelId

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,12 +3,25 @@ chrome.browserAction.setBadgeBackgroundColor({ color: isActive ? '#0097ff' : '#7
 chrome.browserAction.setBadgeText({
 	text: isActive ? 'On' : 'Off'
 });
+
+function blockRequestIfContainsReelId(details) {
+	const variablesString = details.requestBody?.formData?.variables?.[0];
+	if (variablesString) {
+		try {
+			const variables = JSON.parse(variablesString);
+			if (variables.reelId !== undefined) {
+				return { cancel: true };
+			};
+		} catch (error) {
+			console.log("Error parsing variablesString");
+		};
+	};
+};
+
 chrome.webRequest.onBeforeRequest.addListener(
-	() => ({
-		cancel: isActive
-	}),
-	{ urls: [ '*://*.instagram.com/api/v1/stories/reel/seen*', '*://*.instagram.com/api/graphql*' ] },
-	[ 'blocking' ]
+	blockRequestIfContainsReelId,
+	{ urls: [ '*://*.instagram.com/api/graphql*' ] },
+	[ 'blocking', 'requestBody']
 );
 
 chrome.browserAction.onClicked.addListener(() => {


### PR DESCRIPTION
Instead of blocking all GraphQL requests, which leads to the site crashing, I've adapted the code to only block requests that have a reelId (seems to be something related to stories) as a variable in their requestBody. 

Obviously, I haven't tested this extensively; but it seems to work on my machine. Let me know if it works for y'all.